### PR TITLE
Reduce TRANSITION_COMPLETE action clutter

### DIFF
--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -46,10 +46,17 @@ export default (routeConfigMap, stackConfig = {}) => {
         cardStyle={cardStyle}
         transitionConfig={transitionConfig}
         onTransitionStart={onTransitionStart}
-        onTransitionEnd={(lastTransition, transition) => {
+        onTransitionEnd={(transition, lastTransition) => {
           const { state, dispatch } = props.navigation;
-          dispatch(NavigationActions.completeTransition({ key: state.key }));
-          onTransitionEnd && onTransitionEnd(lastTransition, transition);
+
+          if (
+            transition.navigation.state.isTransitioning &&
+            !lastTransition.navigation.state.isTransitioning
+          ) {
+            dispatch(NavigationActions.completeTransition({ key: state.key }));
+          }
+
+          onTransitionEnd && onTransitionEnd(transition, lastTransition);
         }}
       />
     )


### PR DESCRIPTION
Proper usage of transition complete actions, preventing unnecessary and faulty nav state changes. Reference -> https://github.com/react-navigation/react-navigation/pull/3902/files